### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,7 @@
     "url": "https://github.com/shinnn"
   },
   "repository": "shinnn/max-line-length.js",
-  "license": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/shinnn/max-line-length.js/blob/master/LICENSES.md"
-    }
-  ],
+  "license": "MIT",
   "keywords": [
     "string",
     "line",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
